### PR TITLE
GUARD-250 Order Sync Error Fixed

### DIFF
--- a/src/SquareAccess/Models/Order.cs
+++ b/src/SquareAccess/Models/Order.cs
@@ -21,7 +21,7 @@ namespace SquareAccess.Models
 
 	public static class OrderExtensions
 	{
-		public static SquareOrder ToSvOrder( this Order order, SquareCustomer customer, IEnumerable< SquareItem > items )
+		public static SquareOrder ToSvOrder( this Order order, SquareCustomer customer, IEnumerable< SquareItem > orderCatalogObjects )
 		{
 			return new SquareOrder
 			{
@@ -30,9 +30,14 @@ namespace SquareAccess.Models
 				CheckoutStatus =  order.State,
 				CreateDateUtc = order.CreatedAt.FromRFC3339ToUtc(),
 				UpdateDateUtc = order.UpdatedAt.FromRFC3339ToUtc(),
-				LineItems = order.LineItems?.Select( l => l.ToSvOrderLineItem( items.FirstOrDefault( c => c.VariationId == l.CatalogObjectId ) ) ),
+				LineItems = order.LineItems?.ToSvOrderLineItems( orderCatalogObjects ),
 				Customer = customer
 			};
+		}
+
+		public static IEnumerable< SquareOrderLineItem > ToSvOrderLineItems( this IEnumerable< OrderLineItem > orderLineItems, IEnumerable< SquareItem > orderCatalogObjects )
+		{
+			return orderLineItems.Select( l => l.ToSvOrderLineItem( orderCatalogObjects.FirstOrDefault( c => c.VariationId == l.CatalogObjectId ) ) ).Where( l => l != null );
 		}
 	}
 

--- a/src/SquareAccess/Models/OrderLineItem.cs
+++ b/src/SquareAccess/Models/OrderLineItem.cs
@@ -16,6 +16,9 @@ namespace SquareAccess.Models
 	{
 		public static SquareOrderLineItem ToSvOrderLineItem( this OrderLineItem orderLineItem, SquareItem item )
 		{
+			if( item == null )
+				return null;
+
 			return new SquareOrderLineItem
 			{
 				Quantity = orderLineItem.Quantity,

--- a/src/SquareAccessTests/OrderMapperTests.cs
+++ b/src/SquareAccessTests/OrderMapperTests.cs
@@ -81,5 +81,35 @@ namespace SquareAccessTests
 			result.Quantity.Should().Be( quantity );
 			result.UnitPrice.Should().Be( orderLineItem.BasePriceMoney.ToNMoney() );
 		}
+
+		[ Test ]
+		public void ToSvOrderLineItems()
+		{
+			const string catalogObjectId = "lasdkfasdfasdjlk";
+			const string catalogObjectId2 = "as;lkdfj23r422";
+			var quantity = "1";
+			var basePrice = new Money( 123, "USD" );
+			var orderLineItems = new List< OrderLineItem >
+			{
+				new OrderLineItem( Quantity: quantity, CatalogObjectId: catalogObjectId, BasePriceMoney: basePrice ),
+				new OrderLineItem( Quantity: "2", CatalogObjectId: catalogObjectId2, BasePriceMoney: new Money( 334, "USD" ) )
+			};
+			const string sku = "testSku";
+			var orderCatalogObjects = new List< SquareItem >
+			{
+				new SquareItem
+				{
+					VariationId = catalogObjectId,
+					Sku = sku,
+				}
+			};
+
+			var svOrderLineItems = orderLineItems.ToSvOrderLineItems( orderCatalogObjects ).ToList();
+
+			svOrderLineItems.Should().HaveCount( 1 );
+			svOrderLineItems[ 0 ].Quantity.Should().Be( quantity );
+			svOrderLineItems[ 0 ].Sku.Should().Be( sku );
+			svOrderLineItems[ 0 ].UnitPrice.Value.Should().Be( basePrice.ToNMoney() );
+		}
 	}
 }


### PR DESCRIPTION
Crashed if an order had a line item that’s not found among the CatalogObjects referenced in the order. So we might not be able to get the sku for one item in the order. I made a fix to not import such an item into the SkuVault order, since there’s no Sku. Doesn’t seem to be useful to import quantity and UnitPrice without the Sku.